### PR TITLE
Input Manager

### DIFF
--- a/core/src/com/haw/projecthorse/gamemanager/CoreGameMain.java
+++ b/core/src/com/haw/projecthorse/gamemanager/CoreGameMain.java
@@ -1,15 +1,15 @@
 package com.haw.projecthorse.gamemanager;
 
 import com.badlogic.gdx.Game;
-
 import com.haw.projecthorse.gamemanager.navigationmanager.NavigationManagerImpl;
+import com.haw.projecthorse.intputmanager.InputManager;
 
 public class CoreGameMain extends Game {
 
 	@Override
 	public final void create() {
 
-		
+		InputManager.createInstance();
 		GameManagerImpl gameManager = GameManagerImpl.getInstance();
 		NavigationManagerImpl navigationManager = new NavigationManagerImpl(this);		
 		

--- a/core/src/com/haw/projecthorse/intputmanager/DefaultInputProcessor.java
+++ b/core/src/com/haw/projecthorse/intputmanager/DefaultInputProcessor.java
@@ -1,0 +1,19 @@
+package com.haw.projecthorse.intputmanager;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.InputAdapter;
+import com.haw.projecthorse.gamemanager.GameManagerFactory;
+
+public class DefaultInputProcessor extends InputAdapter {
+
+	@Override
+	public boolean keyDown(int keycode) {
+		if ((keycode == Keys.ESCAPE) || (keycode == Keys.BACK)) {
+			Gdx.app.log("DefaultInputProcessor", "Back Key Detected");
+			GameManagerFactory.getInstance().navigateBack();
+			return true;
+		}
+		return false;
+	}
+}

--- a/core/src/com/haw/projecthorse/intputmanager/InputManager.java
+++ b/core/src/com/haw/projecthorse/intputmanager/InputManager.java
@@ -1,0 +1,122 @@
+package com.haw.projecthorse.intputmanager;
+
+import java.util.ArrayList;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
+
+public class InputManager implements InputProcessor {
+
+	private static ArrayList<InputProcessor> processors = new ArrayList<InputProcessor>();
+	private static InputManager instance;
+	private InputManager() {
+		InputProcessor defaultInputProcessor = new DefaultInputProcessor();
+		addInputProcessor(defaultInputProcessor);
+		Gdx.input.setCatchBackKey(true);
+		Gdx.input.setInputProcessor(this);
+	}
+	
+	public static void createInstance(){
+		instance = new InputManager();
+		
+	}
+
+
+	public static void addInputProcessor(InputProcessor inputProcessor) {
+		processors.add(inputProcessor);
+	}
+
+	public static void removeInputProcessor(InputProcessor inputProcessor) {
+		processors.remove(inputProcessor);
+	}
+
+	public static void clear() {
+		processors.clear();
+		InputProcessor defaultInputProcessor = new DefaultInputProcessor();
+		addInputProcessor(defaultInputProcessor);
+		Gdx.input.setCatchBackKey(true);
+		Gdx.input.setInputProcessor(instance);
+	}
+
+	@Override
+	public boolean keyDown(int keycode) {
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.keyDown(keycode))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean keyUp(int keycode) {		
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.keyUp(keycode))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean keyTyped(char character) {		
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+
+			if (processor.keyTyped(character))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean touchDown(int screenX, int screenY, int pointer, int button) {	
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.touchDown(screenX, screenY, pointer, button))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean touchUp(int screenX, int screenY, int pointer, int button) {		
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.touchUp(screenX, screenY, pointer, button))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean touchDragged(int screenX, int screenY, int pointer) {		
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.touchDragged(screenX, screenY, pointer))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean mouseMoved(int screenX, int screenY) {
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.mouseMoved(screenX, screenY))
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean scrolled(int amount) {
+		for (int i = processors.size()-1; i >= 0; i--) {
+			InputProcessor processor = processors.get(i);
+			if (processor.scrolled(amount))
+				return true;
+		}
+		return false;
+	}
+
+}

--- a/core/src/com/haw/projecthorse/level/applerun/AppleRun.java
+++ b/core/src/com/haw/projecthorse/level/applerun/AppleRun.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.actions.Actions;
 import com.haw.projecthorse.gamemanager.GameManagerFactory;
+import com.haw.projecthorse.intputmanager.InputManager;
 import com.haw.projecthorse.level.Level;
 import com.haw.projecthorse.player.ChangeDirectionAction;
 import com.haw.projecthorse.player.Direction;
@@ -65,8 +66,8 @@ public class AppleRun extends Level {
 		stage.addActor(backgroundGraphics);
 		stage.addActor(horse);
 		stage.addActor(fallingEntities);
+		InputManager.addInputProcessor(this.stage);
 		
-		Gdx.input.setInputProcessor(this.stage);
 	}
 
 	private void initBackground() {

--- a/core/src/com/haw/projecthorse/level/city/City.java
+++ b/core/src/com/haw/projecthorse/level/city/City.java
@@ -3,7 +3,6 @@ package com.haw.projecthorse.level.city;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
@@ -20,7 +19,9 @@ import com.haw.projecthorse.gamemanager.GameManagerFactory;
 import com.haw.projecthorse.gamemanager.navigationmanager.exception.LevelNotFoundException;
 import com.haw.projecthorse.gamemanager.navigationmanager.json.CityObject;
 import com.haw.projecthorse.gamemanager.navigationmanager.json.GameObject;
+import com.haw.projecthorse.intputmanager.InputManager;
 import com.haw.projecthorse.level.Level;
+import com.haw.projecthorse.swipehandler.StageGestureDetector;
 
 public class City extends Level {
 
@@ -41,6 +42,9 @@ public class City extends Level {
 		atlant = AssetManager.load("hamburg", false, false, true);
 		
 		stage = new Stage(this.getViewport(), this.getSpriteBatch());
+		font = new BitmapFont(Gdx.files.internal("pictures/selfmade/font.txt"));
+		font.setScale(.45f, .45f);
+		font.setColor(Color.MAGENTA);
 		try {
 			cityObject = GameManagerFactory.getInstance().getCityObject(getLevelID());
 			addGameButtons();
@@ -50,14 +54,12 @@ public class City extends Level {
 		}
 
 		region = atlant.findRegion("Sankt-Michaelis-Kirche_Hamburg");
-		font = new BitmapFont(Gdx.files.internal("pictures/selfmade/font.txt"));
-		font.setScale(.45f, .45f);
-		font.setColor(Color.MAGENTA);
+		
 
 		Gdx.gl.glClearColor(1, 1, 1, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
-		Gdx.input.setInputProcessor(stage);
+		InputManager.addInputProcessor(stage);
+		
 
 	}
 
@@ -67,7 +69,9 @@ public class City extends Level {
 		imageButtonStyle = new ImageTextButton.ImageTextButtonStyle();
 		imageButtonStyle.down = drawable;
 		imageButtonStyle.up = drawable;
-		imageButtonStyle.font = new BitmapFont();
+	
+		imageButtonStyle.font = new BitmapFont(Gdx.files.internal("pictures/selfmade/font.txt"));;
+		imageButtonStyle.font.scale(-0.5f);
 		imageButtonStyle.fontColor = Color.BLACK;
 
 		GameObject[] games = cityObject.getGames();
@@ -80,7 +84,7 @@ public class City extends Level {
 	private void addGameButton(final GameObject gameObject) {
 
 		ImageTextButton imgTextButton = new ImageTextButton(gameObject.getGameTitle(), imageButtonStyle);
-
+		
 		imgTextButton.addListener(new ChangeListener() {
 			public void changed(ChangeEvent event, Actor actor) {
 				System.out.println("Spiel " + gameObject.getGameTitle() + " soll gestartet werden");
@@ -88,7 +92,8 @@ public class City extends Level {
 
 			}
 		});
-
+		imgTextButton.setWidth(400);
+		imgTextButton.setHeight(150);;
 		imgTextButton.setPosition(200, lastButtonY);
 		lastButtonY = lastButtonY - 200;
 		stage.addActor(imgTextButton);

--- a/core/src/com/haw/projecthorse/level/mainmenu/MainMenu.java
+++ b/core/src/com/haw/projecthorse/level/mainmenu/MainMenu.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.haw.projecthorse.assetmanager.AssetManager;
 import com.haw.projecthorse.gamemanager.GameManagerFactory;
+import com.haw.projecthorse.intputmanager.InputManager;
 import com.haw.projecthorse.level.Level;
 import com.haw.projecthorse.player.ChangeDirectionAction;
 import com.haw.projecthorse.player.Direction;
@@ -91,14 +92,7 @@ public class MainMenu extends Level {
 	}
 
 	private void addBackground() {
-		// Pixmap pixel = new Pixmap(this.width, this.height, Format.RGBA8888);
-		// // Create
-		// // a
-		// pixel.setColor(Color.LIGHT_GRAY);
-		// pixel.fill();
-		// backgroundTexture = new Texture(pixel, Format.RGBA8888, true);
-		// pixel.dispose(); // No longer needed
-
+	
 		TextureAtlas atlas = AssetManager.load("menu", false, false, true);
 		backgroundTexture = atlas.findRegion("Background");
 		background = new Image(backgroundTexture);
@@ -182,7 +176,7 @@ public class MainMenu extends Level {
 
 	private void initStage(Viewport viewport, Batch batch) {
 		stage = new Stage(viewport, batch);
-		Gdx.input.setInputProcessor(stage); // Now Stage is processing inputs
+		InputManager.addInputProcessor(stage); // Now Stage is processing inputs
 	}
 
 	private void initTable() {
@@ -196,15 +190,7 @@ public class MainMenu extends Level {
 
 	@Override
 	public void doRender(float delta) {
-		/*
-		 * if(playerMoveRight){ if(player.getX()> Gdx.graphics.getWidth()){
-		 * player.setAnimation(Direction.LEFT, 0.3f); playerMoveRight = false; }
-		 * else player.setPosition(player.getX()+5, player.getY()); }else{
-		 * if(player.getX()<-100-player.getWidth()){
-		 * player.setAnimation(Direction.RIGHT, 0.3f); playerMoveRight = true; }
-		 * else player.setPosition(player.getX()-5, player.getY()); }
-		 */
-
+	
 		Gdx.gl.glClearColor(1, 1, 1, 1); // Hintergrund malen - einfarbig,
 											// langweilig
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/core/src/com/haw/projecthorse/level/parcours/Parcours.java
+++ b/core/src/com/haw/projecthorse/level/parcours/Parcours.java
@@ -15,6 +15,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.actions.Actions;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.haw.projecthorse.assetmanager.AssetManager;
+import com.haw.projecthorse.intputmanager.InputManager;
 import com.haw.projecthorse.level.Level;
 import com.haw.projecthorse.player.Direction;
 import com.haw.projecthorse.player.Player;
@@ -106,8 +107,8 @@ public class Parcours extends Level {
 		initObstacles();
 		
 		stage.addActor(player);
-	
-		Gdx.input.setInputProcessor(this.stage);
+		InputManager.addInputProcessor(stage);
+	//	Gdx.input.setInputProcessor(this.stage);
 		 
 	}
 	

--- a/core/src/com/haw/projecthorse/level/test/MovementTest.java
+++ b/core/src/com/haw/projecthorse/level/test/MovementTest.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.haw.projecthorse.intputmanager.InputManager;
 import com.haw.projecthorse.level.Level;
 import com.haw.projecthorse.player.ChangeDirectionAction;
 import com.haw.projecthorse.player.Player;
@@ -156,7 +157,8 @@ public class MovementTest extends Level {
 		 *  er leitet die Standard-Events (z.B. keyDown oder mouseMoved) an die angegebene
 		 *  Stage weiter. Der übergebene SwipeListener - hier der Player - reagiert auf die Swipe-Events.
 		 */
-		Gdx.input.setInputProcessor(new StageGestureDetector(stage, true, mode));
+		InputManager.addInputProcessor(new StageGestureDetector(stage, true, mode));
+		
 	}
 
 	@Override

--- a/core/src/com/haw/projecthorse/level/worldmap/WorldMap.java
+++ b/core/src/com/haw/projecthorse/level/worldmap/WorldMap.java
@@ -18,6 +18,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.haw.projecthorse.assetmanager.AssetManager;
 import com.haw.projecthorse.gamemanager.GameManagerFactory;
+import com.haw.projecthorse.intputmanager.InputManager;
 import com.haw.projecthorse.level.Level;
 
 public class WorldMap extends Level {
@@ -34,7 +35,7 @@ public class WorldMap extends Level {
 	public WorldMap() {
 		super(); 
 		stage = new Stage(getViewport());
-		Gdx.input.setInputProcessor(stage);
+		InputManager.addInputProcessor(stage);
 		germanyatlas = AssetManager.load("worldmap", false, false, true);
 		germanytexture = germanyatlas.findRegion("germanymap_scaled");
 		//texture.getTexture();


### PR DESCRIPTION
Hey Leute,
Ich hab mal die Gdx.input.setInputProcessor Funktion in einen Input Manager abstrahiert.
So können wir Globale Events (Zurück Button) zum Beispiel immer abfangen.
Die Funktion Gdx.input.setInputProcessor hab ich jetzt durch InputManager.addInputProcessor ersetzt.
So bleibt eigentlich erstmal alles beim alten. Aber wir können trotzdem das InputProcessing leichter erweitern.
Was denkt ihr? 
